### PR TITLE
Fix backups retention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7379,7 +7379,7 @@ dependencies = [
 
 [[package]]
 name = "warden"
-version = "0.3.2-beta.4"
+version = "0.3.2-beta.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/storage/src/integration.rs
+++ b/storage/src/integration.rs
@@ -259,6 +259,17 @@ impl PostgresBackupStorage {
             let file_path = file.path();
             if file_path.is_file() {
                 let file_name = file.file_name().to_string_lossy().to_string();
+
+                // Skip .dump files - they are uploaded separately via upload_logical_backup()
+                // to avoid storing duplicate data under different names
+                if file_name.ends_with(".dump") {
+                    info!(
+                        "Skipping {} (will be uploaded via upload_logical_backup)",
+                        file_name
+                    );
+                    continue;
+                }
+
                 info!("Uploading file: {} ({})", file_name, file_path.display());
                 match self
                     .upload_backup_stream(backup_id, &file_name, &file_path, metadata.clone())


### PR DESCRIPTION
Add conditional check to skip .dump files during directory upload since they are handled separately via upload_logical_backup(). This prevents storing the same backup data twice under different names.